### PR TITLE
Fix missing headers linux distribution build error

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/*.hpp

--- a/setup.py
+++ b/setup.py
@@ -8,20 +8,24 @@ from pybind11 import get_cmake_dir
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup, Extension, find_packages
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 
 ext_modules = [
     Pybind11Extension("binary2strings",
         sorted(glob("src/*.cpp")),  # Sort source files for reproducibility
-        headers = sorted(glob("src/*.hpp")), # Critical for Linux package building
         define_macros = [('VERSION_INFO', __version__)],
         include_dirs = ["src"],
         ),
 ]
 
 # Note to self to build and upload skip existing:
+#   Delete dist/ and build/
 #   python setup.py sdist bdist_wheel
 #   twine upload dist/* --skip-existing
+#     Get token from https://pypi.org/manage/account/token/
+#     Use username __token__
+#     Use password from token
+#     Delete token after use
 with open("README.md", "r") as fh:
     long_description = fh.read()
 setup(

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,12 @@ from pybind11 import get_cmake_dir
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup, Extension, find_packages
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"
 
 ext_modules = [
     Pybind11Extension("binary2strings",
         sorted(glob("src/*.cpp")),  # Sort source files for reproducibility
+        headers = sorted(glob("src/*.hpp")), # Critical for Linux package building
         define_macros = [('VERSION_INFO', __version__)],
         include_dirs = ["src"],
         ),


### PR DESCRIPTION
Fixes #20 . Force include the .hpp files in the distribution package. Credits to ChatGPT-4 for helping me quickly solve this issue.